### PR TITLE
允许小文件秒传链接生成

### DIFF
--- a/miaochuan.sh
+++ b/miaochuan.sh
@@ -75,11 +75,6 @@ mc() {
 
   size=$(wc -c "$f" | awk '{ print $1 }')
 
-  if [ "$SHORT" != true ] && [ "$size" -lt $HEAD_SIZE ]; then
-    error "$SCRIPT: $file: Size must be >= 256 KiB"
-    return 1
-  fi
-
   result=$(do_md5 <"$f")
   if [ "$SHORT" != true ]; then
     result="$result#$(head -c $HEAD_SIZE "$file" | do_md5)"


### PR DESCRIPTION
对于小文件（<256KiB），百度网盘本身也支持秒传。

在我的使用场景中，会将一个文件夹上传（秒传）到百度网盘，有时这些文件夹内有txt之类的说明文件，这些文件很小，但也需要上传。如果不使用这个，我之后又要单独逐个找路径上传文件，很麻烦